### PR TITLE
Fixed bug: loading save data may fail when the file contains 0x1A (EOF) byte.

### DIFF
--- a/autoload/rogue/save.lua
+++ b/autoload/rogue/save.lua
@@ -4,7 +4,7 @@ g.save_file = 'rogue_vim.save'
 
 local function save_into_file(fname)
 	fname = g.expand_fname(fname, g.game_dir)
-	local fp = io.open(fname, "w")
+	local fp = io.open(fname, "wb")
 	if not fp then
 		g.message(g.mesg[503])
 		return
@@ -100,7 +100,7 @@ end
 
 function g.restore(fname)
 	fname = g.expand_fname(fname, g.game_dir)
-	local fp = io.open(fname, "r")
+	local fp = io.open(fname, "rb")
 	if not fp then
 		g.message(g.mesg[504])
 		return false

--- a/autoload/rogue/score.lua
+++ b/autoload/rogue/score.lua
@@ -340,7 +340,7 @@ end
 function g.put_scores(monster, other)
 	local scores = {}
 	local file = g.game_dir .. score_file
-	local fp = io.open(file, "r")
+	local fp = io.open(file, "rb")
 	if fp then
 		local buf = fp:read("*a")
 		g.xxx(true)
@@ -366,7 +366,7 @@ function g.put_scores(monster, other)
 	end
 
 	if rank <= MAX_RANK then
-		fp = io.open(file, "w")
+		fp = io.open(file, "wb")
 		if not fp then
 			g.message(g.mesg[186])
 			sf_error()

--- a/autoload/rogue/util.lua
+++ b/autoload/rogue/util.lua
@@ -12,6 +12,10 @@ g.bxor = nil
 local bit_exists, bit = pcall(require, "bit")
 if bit_exists then
 	g.bxor = bit.bxor
+elseif _VERSION >= 'Lua 5.3' then
+	g.bxor = function(x, y)
+		return x ~ y
+	end
 elseif _VERSION >= 'Lua 5.2' then
 	g.bxor = bit32.bxor
 else


### PR DESCRIPTION
いつも楽しく遊ばせていただいております。
自分の環境（Windows Pro 64bit / Vim 8.2.1783 / Lua 5.3.5）において、セーブファイルを開くための`io.open()`に`b`フラグがないため、ファイルに0x1A（EOF）が含まれるときにそれ以降が読み込まれず、読み込みに失敗していました。
以前は正常にプレイできていたと思うのですが、たまたまうまく行っていただけなのか、Luaか何かのバージョンアップで起こるようになった問題なのかは不明です。

ついでに、Lua 5.3以上では非推奨となったbit32の代わりにビット演算子を使うようにしておきました。